### PR TITLE
Adding fontsize setting for hierarchy navbar

### DIFF
--- a/VHDL.sublime-settings
+++ b/VHDL.sublime-settings
@@ -22,6 +22,7 @@
 	// Navigation config
 	"vhdl.hierarchy_new_window" : false,  // True to open a new window to display the module hierarchy
 	"vhdl.navbar_width" : 0.3, // Navigation bar width (default 0.2 means 20%)
+	"vhdl.navbar_font_size" : 10, // Navigation bar font size (if value is set to 0 then fontsize change is disabled)
 	"vhdl.navbar_show_port"   : true, // Show all ports of current module
 	"vhdl.navbar_show_signal" : true, // Show all signal declared in a module
 	"vhdl.navbar_show_process": true, // Show all named process declared in a module

--- a/vhdl_navigation.py
+++ b/vhdl_navigation.py
@@ -721,6 +721,7 @@ class VhdlShowNavbarCommand(sublime_plugin.TextCommand):
             navBar[wid]['settings']['show_process'] = self.view.settings().get('vhdl.navbar_show_process',False)
             navBar[wid]['settings']['show_alias'] = self.view.settings().get('vhdl.navbar_show_alias',False)
             navBar[wid]['settings']['show_const'] = self.view.settings().get('vhdl.navbar_show_const',False)
+            navBar[wid]['settings']['font_size'] = self.view.settings().get('vhdl.navbar_font_size',10)
         else :
             navBar[wid]['view'].run_command("select_all")
             navBar[wid]['view'].run_command("right_delete")
@@ -1042,6 +1043,12 @@ class VhdlUpdateNavbarCommand(sublime_plugin.EventListener):
             navbar_flag = w.settings().get('navbar-hdl-shared', 0)
             if navbar_flag & 1 == 0 :
                 view.run_command("verilog_show_navbar")
+
+        # Changes fontsize of navbar content.
+        if 'text.hierarchy' in scope:
+            fontSize = navBar[wid]['settings']['font_size']
+            if fontSize > 0:
+                view.settings().set("font_size", fontSize)
 
 # Update the navigation bar
 class VhdlToggleLockNavbarCommand(sublime_plugin.WindowCommand):


### PR DESCRIPTION
Added this feature:
https://github.com/TheClams/SmartVHDL/issues/31

- font size is set to default 10 (same as default for sublime)
- if font size is 0 then the behaviour is the same as before - font size changes with mouse "zoom in/out"